### PR TITLE
Bake micromamba run shell into typescript

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -67813,9 +67813,11 @@ var generateMicromambaRunShell = () => {
     return Promise.resolve();
   }
   core5.info("Generating micromamba run shell.");
-  const micromambaShellFile = fs6.readFile("src/resources/micromamba-shell", { encoding: "utf8" });
-  return Promise.all([micromambaShellFile, determineEnvironmentName(options.environmentName, options.environmentFile)]).then(([fileContents, environmentName]) => {
-    const file = fileContents.replace(/\$MAMBA_EXE/g, options.micromambaBinPath).replace(/\$MAMBA_ROOT_PREFIX/g, options.micromambaRootPath).replace(/\$MAMBA_DEFAULT_ENV/g, environmentName);
+  const micromambaRunShellContents = `#!/bin/env bash
+chmod +x $1
+$MAMBA_EXE run -r $MAMBA_ROOT_PREFIX -n $MAMBA_DEFAULT_ENV $1`;
+  return Promise.all([determineEnvironmentName(options.environmentName, options.environmentFile)]).then(([environmentName]) => {
+    const file = micromambaRunShellContents.replace(/\$MAMBA_EXE/g, options.micromambaBinPath).replace(/\$MAMBA_ROOT_PREFIX/g, options.micromambaRootPath).replace(/\$MAMBA_DEFAULT_ENV/g, environmentName);
     return fs6.writeFile(PATHS.micromambaRunShell, file, { encoding: "utf8", mode: 493 });
   }).finally(core5.endGroup);
 };

--- a/dist/index.js
+++ b/dist/index.js
@@ -67818,6 +67818,9 @@ chmod +x $1
 $MAMBA_EXE run -r $MAMBA_ROOT_PREFIX -n $MAMBA_DEFAULT_ENV $1`;
   return Promise.all([determineEnvironmentName(options.environmentName, options.environmentFile)]).then(([environmentName]) => {
     const file = micromambaRunShellContents.replace(/\$MAMBA_EXE/g, options.micromambaBinPath).replace(/\$MAMBA_ROOT_PREFIX/g, options.micromambaRootPath).replace(/\$MAMBA_DEFAULT_ENV/g, environmentName);
+    core5.debug(`Writing micromamba run shell to ${PATHS.micromambaRunShell}`);
+    core5.debug(`File contents:
+${file}`);
     return fs6.writeFile(PATHS.micromambaRunShell, file, { encoding: "utf8", mode: 493 });
   }).finally(core5.endGroup);
 };

--- a/dist/index.js
+++ b/dist/index.js
@@ -67815,12 +67815,13 @@ var generateMicromambaRunShell = () => {
   core5.info("Generating micromamba run shell.");
   const micromambaRunShellContents = `#!/bin/env bash
 chmod +x $1
-$MAMBA_EXE run -r $MAMBA_ROOT_PREFIX -n $MAMBA_DEFAULT_ENV $1`;
-  return Promise.all([determineEnvironmentName(options.environmentName, options.environmentFile)]).then(([environmentName]) => {
+$MAMBA_EXE run -r $MAMBA_ROOT_PREFIX -n $MAMBA_DEFAULT_ENV $1
+`;
+  return determineEnvironmentName(options.environmentName, options.environmentFile).then((environmentName) => {
     const file = micromambaRunShellContents.replace(/\$MAMBA_EXE/g, options.micromambaBinPath).replace(/\$MAMBA_ROOT_PREFIX/g, options.micromambaRootPath).replace(/\$MAMBA_DEFAULT_ENV/g, environmentName);
     core5.debug(`Writing micromamba run shell to ${PATHS.micromambaRunShell}`);
     core5.debug(`File contents:
-${file}`);
+"${file}"`);
     return fs6.writeFile(PATHS.micromambaRunShell, file, { encoding: "utf8", mode: 493 });
   }).finally(core5.endGroup);
 };

--- a/dist/index.js
+++ b/dist/index.js
@@ -67813,7 +67813,7 @@ var generateMicromambaRunShell = () => {
     return Promise.resolve();
   }
   core5.info("Generating micromamba run shell.");
-  const micromambaRunShellContents = `#!/bin/env bash
+  const micromambaRunShellContents = `#!/usr/bin/env sh
 chmod +x $1
 $MAMBA_EXE run -r $MAMBA_ROOT_PREFIX -n $MAMBA_DEFAULT_ENV $1
 `;

--- a/src/main.ts
+++ b/src/main.ts
@@ -131,10 +131,12 @@ const generateMicromambaRunShell = () => {
     return Promise.resolve()
   }
   core.info('Generating micromamba run shell.')
-  const micromambaShellFile = fs.readFile('src/resources/micromamba-shell', { encoding: 'utf8' })
-  return Promise.all([micromambaShellFile, determineEnvironmentName(options.environmentName, options.environmentFile)])
-    .then(([fileContents, environmentName]) => {
-      const file = fileContents
+  const micromambaRunShellContents = `#!/bin/env bash
+chmod +x $1
+$MAMBA_EXE run -r $MAMBA_ROOT_PREFIX -n $MAMBA_DEFAULT_ENV $1`
+  return Promise.all([determineEnvironmentName(options.environmentName, options.environmentFile)])
+    .then(([environmentName]) => {
+      const file = micromambaRunShellContents
         .replace(/\$MAMBA_EXE/g, options.micromambaBinPath)
         .replace(/\$MAMBA_ROOT_PREFIX/g, options.micromambaRootPath)
         .replace(/\$MAMBA_DEFAULT_ENV/g, environmentName)
@@ -150,7 +152,7 @@ const run = async () => {
 
   if (process.platform === 'win32') {
     // Work around bug in Mamba: https://github.com/mamba-org/mamba/issues/1779
-    // This prevents using provision-with-micromamba without bash
+    // This prevents using setup-micromamba without bash
     core.addPath(path.dirname(await io.which('cygpath', true)))
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -133,15 +133,16 @@ const generateMicromambaRunShell = () => {
   core.info('Generating micromamba run shell.')
   const micromambaRunShellContents = `#!/bin/env bash
 chmod +x $1
-$MAMBA_EXE run -r $MAMBA_ROOT_PREFIX -n $MAMBA_DEFAULT_ENV $1`
-  return Promise.all([determineEnvironmentName(options.environmentName, options.environmentFile)])
-    .then(([environmentName]) => {
+$MAMBA_EXE run -r $MAMBA_ROOT_PREFIX -n $MAMBA_DEFAULT_ENV $1
+`
+  return determineEnvironmentName(options.environmentName, options.environmentFile)
+    .then((environmentName) => {
       const file = micromambaRunShellContents
         .replace(/\$MAMBA_EXE/g, options.micromambaBinPath)
         .replace(/\$MAMBA_ROOT_PREFIX/g, options.micromambaRootPath)
         .replace(/\$MAMBA_DEFAULT_ENV/g, environmentName)
       core.debug(`Writing micromamba run shell to ${PATHS.micromambaRunShell}`)
-      core.debug(`File contents:\n${file}`)
+      core.debug(`File contents:\n"${file}"`)
       return fs.writeFile(PATHS.micromambaRunShell, file, { encoding: 'utf8', mode: 0o755 })
     })
     .finally(core.endGroup)

--- a/src/main.ts
+++ b/src/main.ts
@@ -140,6 +140,8 @@ $MAMBA_EXE run -r $MAMBA_ROOT_PREFIX -n $MAMBA_DEFAULT_ENV $1`
         .replace(/\$MAMBA_EXE/g, options.micromambaBinPath)
         .replace(/\$MAMBA_ROOT_PREFIX/g, options.micromambaRootPath)
         .replace(/\$MAMBA_DEFAULT_ENV/g, environmentName)
+      core.debug(`Writing micromamba run shell to ${PATHS.micromambaRunShell}`)
+      core.debug(`File contents:\n${file}`)
       return fs.writeFile(PATHS.micromambaRunShell, file, { encoding: 'utf8', mode: 0o755 })
     })
     .finally(core.endGroup)

--- a/src/main.ts
+++ b/src/main.ts
@@ -131,7 +131,7 @@ const generateMicromambaRunShell = () => {
     return Promise.resolve()
   }
   core.info('Generating micromamba run shell.')
-  const micromambaRunShellContents = `#!/bin/env bash
+  const micromambaRunShellContents = `#!/usr/bin/env sh
 chmod +x $1
 $MAMBA_EXE run -r $MAMBA_ROOT_PREFIX -n $MAMBA_DEFAULT_ENV $1
 `


### PR DESCRIPTION
Unfortunately, `src/resources/micromamba-shell` is not available at runtime. Therefore, we need to bake it into the source code directly.