### PR TITLE
Fix CI, add merge group

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches: main
   pull_request:
     branches: main
+  merge_group:
 
 jobs:
   build:

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -5,6 +5,7 @@ on:
     branches: main
   pull_request:
     branches: main
+  merge_group:
 
 jobs:
   check-dist:

--- a/.github/workflows/test-cache.yml
+++ b/.github/workflows/test-cache.yml
@@ -5,6 +5,7 @@ on:
     branches: main
   pull_request:
     branches: main
+  merge_group:
 
 defaults:
   run:

--- a/.github/workflows/test-post-cleanup.yml
+++ b/.github/workflows/test-post-cleanup.yml
@@ -5,6 +5,7 @@ on:
     branches: main
   pull_request:
     branches: main
+  merge_group:
 
 jobs:
   test-post-cleanup:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches: main
   pull_request:
     branches: main
+  merge_group:
 
 jobs:
   no-environment-file:
@@ -157,7 +158,7 @@ jobs:
           environment-file: 'test/environment.yml'
           condarc-file: 'test/.condarc'
       - run: | # this should only work when the pytorch channel is loaded, i.e., the custom condarc is used
-          micromamba search pytorch=2.0.0 | grep -q "pytorch 2.0.0   py3.10_cpu_0                 pytorch/linux-64"
+          micromamba search pytorch=2.0.0 | grep -q "pytorch 2.0.0   py3.10_cpu_0                 pytorch"
         shell: bash -el {0}
     
   output-environment-path-env-file:


### PR DESCRIPTION
Old micromamba versions:

```bash
❯ micromamba search pytorch=2.0.0 -c pytorch --platform=linux-64
Getting repodata from channels...

pytorch/noarch                                      10.2kB @  37.1kB/s  0.3s
pytorch/linux-64                                   167.9kB @ 527.8kB/s  0.3s
qc-internal/linux-64                                48.7kB @ 105.2kB/s  0.5s
qc-internal/noarch                                 150.4kB @ 260.8kB/s  0.3s
conda-forge/noarch                                  12.4MB @   3.4MB/s  3.9s
conda-forge/linux-64                                31.8MB @   3.4MB/s 10.1s


 Name    Version Build                        Channel
───────────────────────────────────────────────────────────────────
 pytorch 2.0.0   py3.10_cpu_0                 pytorch/linux-64
 pytorch 2.0.0   py3.10_cuda11.7_cudnn8.5.0_0 pytorch/linux-64
 pytorch 2.0.0   py3.10_cuda11.8_cudnn8.7.0_0 pytorch/linux-64
 pytorch 2.0.0   py3.8_cpu_0                  pytorch/linux-64
 pytorch 2.0.0   py3.8_cuda11.7_cudnn8.5.0_0  pytorch/linux-64
 pytorch 2.0.0   py3.8_cuda11.8_cudnn8.7.0_0  pytorch/linux-64
 pytorch 2.0.0   py3.9_cpu_0                  pytorch/linux-64
 pytorch 2.0.0   py3.9_cuda11.7_cudnn8.5.0_0  pytorch/linux-64
 pytorch 2.0.0   py3.9_cuda11.8_cudnn8.7.0_0  pytorch/linux-64
 pytorch 2.0.0   cpu_py310hd11e9c7_0          conda-forge/linux-64
 pytorch 2.0.0   cpu_py311h410fd25_0          conda-forge/linux-64
 pytorch 2.0.0   cpu_py38h019455c_0           conda-forge/linux-64
 pytorch 2.0.0   cpu_py39he4d1dc0_0           conda-forge/linux-64
 pytorch 2.0.0   cuda112py310he33e0d6_200     conda-forge/linux-64
 pytorch 2.0.0   cuda112py311h13fee9e_200     conda-forge/linux-64
 pytorch 2.0.0   cuda112py38h5e67e12_200      conda-forge/linux-64
 pytorch 2.0.0   cuda112py39ha9981d0_200      conda-forge/linux-64
```

Newer micromamba versions:

```bash
❯ micromamba search pytorch=2.0.0 -c pytorch --platform=linux-64
Getting repodata from channels...

pytorch/linux-64                                            Using cache
pytorch/noarch                                              Using cache
conda-forge/linux-64                                        Using cache
conda-forge/noarch                                          Using cache
qc-internal/linux-64                                        Using cache
qc-internal/noarch                                          Using cache


 Name    Version Build                        Channel
──────────────────────────────────────────────────────────
 pytorch 2.0.0   py3.10_cpu_0                 pytorch
 pytorch 2.0.0   py3.10_cuda11.7_cudnn8.5.0_0 pytorch
 pytorch 2.0.0   py3.10_cuda11.8_cudnn8.7.0_0 pytorch
 pytorch 2.0.0   py3.8_cpu_0                  pytorch
 pytorch 2.0.0   py3.8_cuda11.7_cudnn8.5.0_0  pytorch
 pytorch 2.0.0   py3.8_cuda11.8_cudnn8.7.0_0  pytorch
 pytorch 2.0.0   py3.9_cpu_0                  pytorch
 pytorch 2.0.0   py3.9_cuda11.7_cudnn8.5.0_0  pytorch
 pytorch 2.0.0   py3.9_cuda11.8_cudnn8.7.0_0  pytorch
 pytorch 2.0.0   cpu_py310hd11e9c7_0          conda-forge
 pytorch 2.0.0   cpu_py311h410fd25_0          conda-forge
 pytorch 2.0.0   cpu_py38h019455c_0           conda-forge
 pytorch 2.0.0   cpu_py39he4d1dc0_0           conda-forge
 pytorch 2.0.0   cuda112py310he33e0d6_200     conda-forge
 pytorch 2.0.0   cuda112py311h13fee9e_200     conda-forge
 pytorch 2.0.0   cuda112py38h5e67e12_200      conda-forge
 pytorch 2.0.0   cuda112py39ha9981d0_200      conda-forge
```