### PR TITLE
Add pnpm to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,10 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "weekly"
+      interval: weekly
+  - package-ecosystem: pnpm
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
pnpm is now available in dependabot, see [here](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates#pnpm)