### PR TITLE
Dependabot pnpm -> npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
-  - package-ecosystem: pnpm
+  - package-ecosystem: npm
     directory: /
     schedule:
       interval: weekly


### PR DESCRIPTION
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem

Apparently the yaml value should be called `npm`.