### PR TITLE
Improve Shell Default Arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,19 +304,19 @@ Please see [this comment for now](https://github.com/mamba-org/provision-with-mi
 
 ## About login shells...
 
-Some shells require special syntax (e.g. `bash -l {0}`). You can set this up with the `defaults` option:
+Some shells require special syntax (e.g. `bash -leo pipefail {0}`). You can set this up with the `defaults` option:
 
 ```yaml
 jobs:
   myjob:
     defaults:
       run:
-        shell: bash -l {0}
+        shell: bash -leo pipefail {0} {0}
 
 # or top-level:
 defaults:
   run:
-    shell: bash -l {0}
+    shell: bash -leo pipefail {0} {0}
 jobs:
   ...
 ```
@@ -324,7 +324,7 @@ jobs:
 Find the reasons below (taken from [setup-miniconda](https://github.com/conda-incubator/setup-miniconda/blob/master/README.md#important)):
 
 - Bash shells do not use `~/.profile` or `~/.bashrc` so these shells need to be
-  explicitly declared as `shell: bash -l {0}` on steps that need to be properly
+  explicitly declared as `shell: bash -leo pipefail {0}` on steps that need to be properly
   activated (or use a default shell). This is because bash shells are executed
   with `bash --noprofile --norc -eo pipefail {0}` thus ignoring updated on bash
   profile files made by `micromamba shell init bash`.


### PR DESCRIPTION
Resolves #151

Advise users to use "bash -leo pipefail {0}" instead of "bash -l {0}" since without "-eo pipefail" errors can happen in a shell script, but keep CI running without an error. Most users will want a shell where if a pipe eats a non zero exit, the program propigates the error.