### PR TITLE
fix typo in suggested default shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,12 +339,12 @@ jobs:
   myjob:
     defaults:
       run:
-        shell: bash -leo pipefail {0} {0}
+        shell: bash -leo pipefail {0}
 
 # or top-level:
 defaults:
   run:
-    shell: bash -leo pipefail {0} {0}
+    shell: bash -leo pipefail {0}
 jobs:
   ...
 ```


### PR DESCRIPTION
Fixes a typo I introduced in PR #152 :see_no_evil: 