### PR TITLE
Include bin hash in cache key

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./
       - run: |
-          micromamba info | grep -q "environment : None (not found)"
+          micromamba info | grep -q "environment : base"
         shell: bash -el {0}
 
   micromamba-old-version-1:
@@ -170,7 +170,7 @@ jobs:
           condarc-file: 'test/.condarc'
       - run: | # this should only work when the pytorch channel is loaded, i.e., the custom condarc is used
           micromamba search pytorch=2.0.0
-          micromamba search pytorch=2.0.0 | grep -q "pytorch 2.0.0 py3.10_cpu_0"
+          micromamba search pytorch=2.0.0 | grep -q "pytorch 2.0.0   py3.10_cpu_0"
         shell: bash -el {0}
 
   conda-lock:

--- a/dist/main.js
+++ b/dist/main.js
@@ -82934,7 +82934,7 @@ var generateEnvironmentKey = (options, prefix2) => {
   const envName = options.environmentName ? `-${options.environmentName}` : "";
   const createArgs = options.createArgs ? `-args-${sha256Short(JSON.stringify(options.createArgs))}` : "";
   const rootPrefix = `-root-${sha256Short(options.micromambaRootPath)}`;
-  const binHash = fs5.readBinaryFile(options.micromambaBinPath).then(sha256);
+  const binHash = fs5.readFile(options.micromambaBinPath).then(sha256);
   const key = `${prefix2}${arch3}${envName}${createArgs}${rootPrefix}-bin-${binHash}`;
   if (options.environmentFile) {
     return fs5.readFile(options.environmentFile, "utf-8").then((content) => {

--- a/dist/main.js
+++ b/dist/main.js
@@ -82934,7 +82934,8 @@ var generateEnvironmentKey = (options, prefix2) => {
   const envName = options.environmentName ? `-${options.environmentName}` : "";
   const createArgs = options.createArgs ? `-args-${sha256Short(JSON.stringify(options.createArgs))}` : "";
   const rootPrefix = `-root-${sha256Short(options.micromambaRootPath)}`;
-  const key = `${prefix2}${arch3}${envName}${createArgs}${rootPrefix}`;
+  const binHash = fs5.readBinaryFile(options.micromambaBinPath).then(sha256);
+  const key = `${prefix2}${arch3}${envName}${createArgs}${rootPrefix}-bin-${binHash}`;
   if (options.environmentFile) {
     return fs5.readFile(options.environmentFile, "utf-8").then((content) => {
       const keyWithFileSha = `${key}-file-${sha256(content)}`;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-micromamba",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "private": true,
   "description": "Action to setup micromamba",
   "scripts": {

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -40,7 +40,11 @@ const generateEnvironmentKey = (options: Options, prefix: string) => {
   const envName = options.environmentName ? `-${options.environmentName}` : ''
   const createArgs = options.createArgs ? `-args-${sha256Short(JSON.stringify(options.createArgs))}` : ''
   const rootPrefix = `-root-${sha256Short(options.micromambaRootPath)}`
-  const key = `${prefix}${arch}${envName}${createArgs}${rootPrefix}`
+  const binHash = fs.readBinaryFile(options.micromambaBinPath).then((content) => {
+    return sha256(content)
+  })
+
+  const key = `${prefix}${arch}${envName}${createArgs}${rootPrefix}-bin-${binHash}`
 
   if (options.environmentFile) {
     return fs.readFile(options.environmentFile, 'utf-8').then((content) => {

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -40,9 +40,7 @@ const generateEnvironmentKey = (options: Options, prefix: string) => {
   const envName = options.environmentName ? `-${options.environmentName}` : ''
   const createArgs = options.createArgs ? `-args-${sha256Short(JSON.stringify(options.createArgs))}` : ''
   const rootPrefix = `-root-${sha256Short(options.micromambaRootPath)}`
-  const binHash = fs.readBinaryFile(options.micromambaBinPath).then((content) => {
-    return sha256(content)
-  })
+  const binHash = fs.readBinaryFile(options.micromambaBinPath).then(sha256)
 
   const key = `${prefix}${arch}${envName}${createArgs}${rootPrefix}-bin-${binHash}`
 

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -40,7 +40,7 @@ const generateEnvironmentKey = (options: Options, prefix: string) => {
   const envName = options.environmentName ? `-${options.environmentName}` : ''
   const createArgs = options.createArgs ? `-args-${sha256Short(JSON.stringify(options.createArgs))}` : ''
   const rootPrefix = `-root-${sha256Short(options.micromambaRootPath)}`
-  const binHash = fs.readBinaryFile(options.micromambaBinPath).then(sha256)
+  const binHash = fs.readFile(options.micromambaBinPath).then(sha256)
 
   const key = `${prefix}${arch}${envName}${createArgs}${rootPrefix}-bin-${binHash}`
 


### PR DESCRIPTION
Add sha256 hash of the micromamba binary to the cache key so broken environments created from previous versions won't be restored for a new version.

Closes https://github.com/mamba-org/setup-micromamba/issues/91

