### PR TITLE
bug: Propagate errors from micromamba-shell

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-micromamba",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "description": "Action to setup micromamba",
   "scripts": {

--- a/src/resources/micromamba-shell
+++ b/src/resources/micromamba-shell
@@ -4,4 +4,4 @@
 # The script then executes the contents of the file.
 
 chmod +x $1
-$MAMBA_EXE run -r $MAMBA_ROOT_PREFIX -n $MAMBA_DEFAULT_ENV $1
+exec $MAMBA_EXE run -r $MAMBA_ROOT_PREFIX -n $MAMBA_DEFAULT_ENV $1


### PR DESCRIPTION
If the micromamba-shell command fails, the exit command is not propagated, leading to silent failures.

Consider if possible switching to bash for `-o pipefail` support.